### PR TITLE
update requests version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.25.1
+requests==2.32.3


### PR DESCRIPTION
Having `requests == 2.25` breaks anaconda bashrc integration. see https://github.com/conda/conda/issues/13344

usleep API works fine (at least for me) with 2.32 :)


alternatively, remove version restriction completely, the requests API should be mroe or less backwards compatible