### PR TITLE
make requests dependency flexible 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests>=2.32.3
+requests>2,<3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests>2,<3
+requests>2.28,<3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.32.3
+requests>=2.32.3


### PR DESCRIPTION
Having the requirement at a fixed version number will interfer with other packages that actually need a specific version, I suggest making it upwards compatibility, unless explicitly breaking changes are made to requests (which would be announced in a major version 3).


